### PR TITLE
Adjust url in menu to get straight to the nuxt.js

### DIFF
--- a/src/vuepress.config.js
+++ b/src/vuepress.config.js
@@ -128,7 +128,8 @@ module.exports = {
       },
     },
 
-    repo: `druxt/${meta.name}`,
+    repo: `${meta.repository.url.replace(/^git\+/, "") ||
+      `druxt/${meta.name}`}`,
 
     sidebarDepth: 4,
 


### PR DESCRIPTION
At the moment people end up on https://github.com/druxt/druxt if they click on the Github-Entry in the Menu. But what they probably want to do is to contribute/check/install the package. Therefore https://github.com/druxt/druxt.js might be the better choice.